### PR TITLE
Copy Topic Part + Clear Topic Fixes

### DIFF
--- a/src/renderer/src/components/CopyContextMenu.vue
+++ b/src/renderer/src/components/CopyContextMenu.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { QMenu } from 'quasar'
+
+withDefaults(
+  defineProps<{
+    contextMenu?: boolean
+    anchor?: QMenu['anchor']
+    self?: QMenu['self']
+  }>(),
+  {
+    contextMenu: true,
+    anchor: 'bottom right',
+    self: 'top right'
+  }
+)
+
+defineEmits(['copy'])
+</script>
+
+<template>
+  <q-menu :anchor="anchor" :self="self" :context-menu="contextMenu">
+    <q-list class="tw-min-w-[150px]">
+      <q-item class="tw-text-secondary" clickable v-close-popup @click="$emit('copy')">
+        <q-item-section>
+          <div>
+            <q-icon name="fa-solid fa-copy" class="tw-mr-2" />
+            Copy
+          </div>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-menu>
+</template>
+
+<style scoped lang="less"></style>

--- a/src/renderer/src/components/tap-topics/TabValues.vue
+++ b/src/renderer/src/components/tap-topics/TabValues.vue
@@ -2,14 +2,18 @@
 import { MqttMessage, useMqttTopicsStore } from '../../store/mqtt-topics'
 import { ElectronIpc } from '../../../../types/electron-ipc-callbacks'
 import { useSettingsStore } from '../../store/settings-store'
+import CopyContextMenu from '../CopyContextMenu.vue'
 import EraseButton from '../buttons/EraseButton.vue'
 import CopyButton from '../buttons/CopyButton.vue'
 import SplitterIcon from '../SplitterIcon.vue'
 import MessagesList from './MessagesList.vue'
 import CodePreview from './CodePreview.vue'
 import { computed, ref, watch } from 'vue'
+import { useQuasar } from 'quasar'
 
 const electronApi = window.api as ElectronIpc
+
+const $q = useQuasar()
 
 const mqttTopicsStore = useMqttTopicsStore()
 const settingsStore = useSettingsStore()
@@ -33,6 +37,17 @@ const handleBreadcrumbClick = (index: number) => {
     mqttTopicsStore.selectedConnection,
     breadcrumbs.value.slice(0, index + 1).join('/')
   )
+}
+
+const handleBreadcrumbCopyPart = (part: string) => {
+  navigator.clipboard.writeText(part)
+
+  $q.notify({
+    message: 'Topic key copied to clipboard',
+    icon: 'fa-solid fa-clipboard',
+    color: 'positive',
+    timeout: 1000
+  })
 }
 
 const handleEraseTopic = () => {
@@ -94,7 +109,13 @@ watch(
             clickable
             :label="topicPart ? topicPart : '<\empty>'"
             @click="handleBreadcrumbClick(index)"
-          />
+          >
+            <copy-context-menu
+              anchor="bottom left"
+              self="top left"
+              @copy="handleBreadcrumbCopyPart(topicPart)"
+            />
+          </q-chip>
         </q-breadcrumbs-el>
       </q-breadcrumbs>
     </div>

--- a/src/renderer/src/components/tap-topics/TopicItem.vue
+++ b/src/renderer/src/components/tap-topics/TopicItem.vue
@@ -62,6 +62,17 @@ const handleCopyTopic = () => {
   })
 }
 
+const handleCopyTopicKey = () => {
+  navigator.clipboard.writeText(props.topicKey)
+
+  $q.notify({
+    message: 'Topic key copied to clipboard',
+    icon: 'fa-solid fa-clipboard',
+    color: 'positive',
+    timeout: 1000
+  })
+}
+
 const handleCopyLastMessage = () => {
   if (topicLastMessage.value?.message) {
     navigator.clipboard.writeText(topicLastMessage.value.message)
@@ -163,6 +174,7 @@ watch(
           <topic-item-menu
             :hide-copy-last-message="!topicLastMessage?.message"
             @copy-last-message="handleCopyLastMessage"
+            @copy-topic-key="handleCopyTopicKey"
             @copy-topic="handleCopyTopic"
             @erase="handleEraseTopic"
           />
@@ -203,6 +215,7 @@ watch(
         <topic-item-menu
           :hide-copy-last-message="!topicLastMessage?.message"
           @copy-last-message="handleCopyLastMessage"
+          @copy-topic-key="handleCopyTopicKey"
           @copy-topic="handleCopyTopic"
           @erase="handleEraseTopic"
         />

--- a/src/renderer/src/components/tap-topics/TopicItemMenu.vue
+++ b/src/renderer/src/components/tap-topics/TopicItemMenu.vue
@@ -3,7 +3,7 @@ defineProps<{
   hideCopyLastMessage?: boolean
 }>()
 
-defineEmits(['copyLastMessage', 'copyTopic', 'erase'])
+defineEmits(['copyLastMessage', 'copyTopic', 'copyTopicKey', 'erase'])
 </script>
 
 <template>
@@ -14,6 +14,15 @@ defineEmits(['copyLastMessage', 'copyTopic', 'erase'])
           <div>
             <q-icon name="fa-solid fa-copy" class="tw-mr-2" />
             Copy Topic
+          </div>
+        </q-item-section>
+      </q-item>
+
+      <q-item class="tw-text-secondary" clickable v-close-popup @click="$emit('copyTopicKey')">
+        <q-item-section>
+          <div>
+            <q-icon name="fa-solid fa-copy" class="tw-mr-2" />
+            Copy Topic Key
           </div>
         </q-item-section>
       </q-item>

--- a/src/renderer/src/store/mqtt-topics.ts
+++ b/src/renderer/src/store/mqtt-topics.ts
@@ -286,9 +286,9 @@ export const useMqttTopicsStore = defineStore('mqtt-topics', {
       this.subTopicsMessagesCount[clientKey] = {}
       this.topicsStructure[clientKey] = {}
     },
-    clearTopicsAndSubTopicsMessages(clientKey: string, topic: string) {
-      const topics = Object.keys(this.topicsMessages[clientKey]).filter((filterTopic) => {
-        return filterTopic.startsWith(topic)
+    clearTopicsAndSubTopicsMessages(clientKey: string, topicToRemove: string) {
+      const topics = Object.keys(this.subTopicsTopicsCount[clientKey]).filter((topic) => {
+        return topic.startsWith(`${topicToRemove}/`) || topic === topicToRemove
       })
 
       for (const topic of topics) {
@@ -298,7 +298,7 @@ export const useMqttTopicsStore = defineStore('mqtt-topics', {
         delete this.subTopicsMessagesCount[clientKey][topic]
       }
 
-      this.clearTopicsAndSubTopicsStructure(clientKey, topic)
+      this.clearTopicsAndSubTopicsStructure(clientKey, topicToRemove)
     },
     clearTopicsAndSubTopicsStructure(clientKey: string, topic: string) {
       const topicParts = topic.split('/')


### PR DESCRIPTION
Added:
Copy topic parts

Fix:
Deleting a topic and its data could delete other topics with a similar name
Deleting a topic did not delete messages count/subtopics count if it didn't contain a message