### PR TITLE
Fix arrow key navigation wrong scroll

### DIFF
--- a/src/renderer/src/components/tap-topics/TopicItem.vue
+++ b/src/renderer/src/components/tap-topics/TopicItem.vue
@@ -148,7 +148,7 @@ watch(
 <template>
   <div v-if="!isLastTopicPart" :id="`topic-item-${topicPath}`">
     <div class="tw-flex">
-      <q-intersection class="tw-h-[29px]">
+      <q-intersection :id="`topic-item-${topicPath}-intersection`" class="tw-h-[29px]">
         <topic-card
           ref="topicGroupTopicCardRef"
           expandable
@@ -196,7 +196,7 @@ watch(
     </template>
   </div>
   <div v-else class="tw-flex" :id="`topic-item-${topicPath}`">
-    <q-intersection class="tw-h-[29px]">
+    <q-intersection :id="`topic-item-${topicPath}-intersection`" class="tw-h-[29px]">
       <topic-card
         ref="topicCardRef"
         :has-actions="hasActions"

--- a/src/renderer/src/tabs/TabTopics.vue
+++ b/src/renderer/src/tabs/TabTopics.vue
@@ -250,7 +250,7 @@ const handleRightKey = () => {
 
 const handleScrollPreviousTopic = (previousTopic: string) => {
   const virtualScroll = document.getElementById('topicsVirtualScroll')
-  const element = document.getElementById(`topic-item-${previousTopic}`)
+  const element = document.getElementById(`topic-item-${previousTopic}-intersection`)
 
   if (virtualScroll && element) {
     if (element.offsetTop < virtualScroll.scrollTop) {
@@ -266,7 +266,7 @@ const handleScrollPreviousTopic = (previousTopic: string) => {
 
 const handleScrollNextTopic = (nextTopic: string) => {
   const virtualScroll = document.getElementById('topicsVirtualScroll')
-  const element = document.getElementById(`topic-item-${nextTopic}`)
+  const element = document.getElementById(`topic-item-${nextTopic}-intersection`)
 
   if (virtualScroll && element) {
     if (


### PR DESCRIPTION
Fix:
- When going down an opened topic group using arrow keys would scroll down to the bottom of the group