### PR TITLE
Fix Arrow Navigation prevent + Remove Menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,8 @@ function createWindow(): void {
     }
   })
 
+  mainWindow.removeMenu()
+
   initIpcMain()
 
   mainWindow.on('close', () => {

--- a/src/renderer/src/tabs/TabTopics.vue
+++ b/src/renderer/src/tabs/TabTopics.vue
@@ -161,11 +161,19 @@ const topicToSelect = (index: number, direction: 'up' | 'down'): string | null =
 }
 
 const handleKeyUp = (event: KeyboardEvent) => {
+  if (['ArrowUp', 'ArrowDown'].includes(event.key)) {
+    event.preventDefault()
+  }
+
   if (event.key === 'ArrowUp') handleUpKeyUp()
   else if (event.key === 'ArrowDown') handleDownKeyUp()
 }
 
 const handleKeyDown = (event: KeyboardEvent) => {
+  if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+    event.preventDefault()
+  }
+
   if (event.key === 'ArrowUp') handleUpKeyDown()
   else if (event.key === 'ArrowDown') handleDownKeyDown()
   else if (event.key === 'ArrowLeft') handleLeftKey()
@@ -314,11 +322,7 @@ const handleScrollNextTopic = (nextTopic: string) => {
               />
             </div>
             <q-separator />
-            <div
-              class="tw-overflow-auto"
-              @keyup.prevent="handleKeyUp"
-              @keydown.prevent="handleKeyDown"
-            >
+            <div class="tw-overflow-auto" @keyup="handleKeyUp" @keydown="handleKeyDown">
               <q-virtual-scroll
                 id="topicsVirtualScroll"
                 v-slot="{ item: [_, value] }"


### PR DESCRIPTION
Update:
- Removed menu from app (Windows: could see it when pressing Alt)

Fix:
- Issue where when focusing on topics tab prevents all system shortcut from being used