### PR TITLE
fix: export action group was bugged

### DIFF
--- a/src/renderer/src/store/chain-actions.ts
+++ b/src/renderer/src/store/chain-actions.ts
@@ -17,6 +17,8 @@ export const useChainActionsStore = defineStore('chain-actions', {
     getGroupChainActionsRecord: (state) => (connectionId: string, groupId: string) => {
       const record = state.chainActions[connectionId]
 
+      if (!record) return {}
+
       return { [groupId]: record[groupId] }
     },
     getChainAction: (state) => (chainActionId: string) => {


### PR DESCRIPTION
Fix:
- Exporting groups with no Chain Actions created wouldn't work