### PR TITLE
feat: connection label

### DIFF
--- a/src/renderer/src/components/AppBar.vue
+++ b/src/renderer/src/components/AppBar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import ConnectionContextMenu from '@renderer/components/tap-topics/ConnectionContextMenu.vue'
 import { useMqttConnectionsStore } from '@renderer/store/mqtt-connections'
+import { useLabelColors } from '@renderer/composables/useLabelColors'
 import { useMqttTopicsStore } from '@renderer/store/mqtt-topics'
 import ConnectionStatusBadge from './ConnectionStatusBadge.vue'
 import { AppPlatform } from '@renderer/assets/js/electron-api'
@@ -10,6 +11,8 @@ import { computed, ref } from 'vue'
 const mqttConnectionsStore = useMqttConnectionsStore()
 const mqttTopicsStore = useMqttTopicsStore()
 const appStore = useAppStore()
+
+const { getColor } = useLabelColors()
 
 const connectedConnections = computed(() => {
   return mqttConnectionsStore.getConnectionsWithStatus
@@ -78,13 +81,16 @@ const isTopicsTab = computed(() => {
       <div
         v-for="connection in connectedConnections"
         :key="connection.clientKey"
-        class="connection-tab"
-        :class="{
-          'tw-text-neutral-400 dark:tw-text-neutral-400':
-            connection.clientKey !== mqttTopicsStore.selectedConnection,
-          'tw-bg-neutral-200 tw-text-black dark:tw-bg-neutral-800 dark:tw-text-white':
-            connection.clientKey === mqttTopicsStore.selectedConnection
-        }"
+        class="connection-tab tw-mt-[1px] tw-border-t-2"
+        :class="[
+          {
+            'tw-text-neutral-400 dark:tw-text-neutral-400':
+              connection.clientKey !== mqttTopicsStore.selectedConnection,
+            'tw-bg-neutral-200 tw-text-black dark:tw-bg-neutral-800 dark:tw-text-white':
+              connection.clientKey === mqttTopicsStore.selectedConnection
+          },
+          getColor(connection.labelColor)?.border ?? 'tw-border-transparent'
+        ]"
         @click="
           () => {
             mqttTopicsStore.selectedConnection = connection.clientKey

--- a/src/renderer/src/components/tab-connections/MqttConnectionCard.vue
+++ b/src/renderer/src/components/tab-connections/MqttConnectionCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import MqttConnectionCardContextMenu from './MqttConnectionCardContextMenu.vue'
 import { useMqttConnectionsStore } from '@renderer/store/mqtt-connections'
+import { useLabelColors } from '@renderer/composables/useLabelColors'
 import { MqttConnection } from '../../../../types/mqtt-connection'
 import { useMqttTopicsStore } from '@renderer/store/mqtt-topics'
 import { useMqttUrl } from '../../composables/useMqttUrl'
@@ -12,6 +13,7 @@ const mqttTopicsStore = useMqttTopicsStore()
 const appStore = useAppStore()
 
 const { formatMqttUrl } = useMqttUrl()
+const { getColor } = useLabelColors()
 
 const props = defineProps<{ connection: MqttConnection }>()
 
@@ -26,7 +28,8 @@ const connectionStatus = computed(() => {
 
 <template>
   <div
-    class="mqtt-connection-card tw-cursor-pointer tw-rounded tw-p-4 dark:tw-bg-neutral-900 dark:hover:tw-bg-neutral-800"
+    class="mqtt-connection-card tw-cursor-pointer tw-rounded tw-border-t-2 tw-p-4 dark:tw-bg-neutral-900 dark:hover:tw-bg-neutral-800"
+    :class="getColor(connection.labelColor)?.border ?? 'tw-border-transparent'"
     @click="
       () => {
         if (connectionStatus === 'disconnected') $emit('connect', connection)

--- a/src/renderer/src/components/tab-connections/MqttConnectionDialog.vue
+++ b/src/renderer/src/components/tab-connections/MqttConnectionDialog.vue
@@ -312,7 +312,7 @@ watch(
                           auto-save
                           @update:model-value="setCustomLabel(selectedColor.value, $event)"
                         >
-                          <div class="text-accent tw-mb-1">My Custom Title</div>
+                          <div class="text-accent tw-mb-1">Edit label name</div>
 
                           <q-input
                             v-model="scope.value"

--- a/src/renderer/src/components/tab-connections/MqttConnectionDialog.vue
+++ b/src/renderer/src/components/tab-connections/MqttConnectionDialog.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { MqttConnection, MqttTopicSubscription } from '../../../../types/mqtt-connection'
+import { useLabelColors } from '@renderer/composables/useLabelColors'
 import AdvancedSettings from '../tab-settings/AdvancedSettings.vue'
 import { QDialog, QForm, QPopupProxy, QTableProps } from 'quasar'
 import { useSettingsStore } from '../../store/settings-store'
 import CodeEditor from '../tap-topics/CodeEditor.vue'
-import { nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { v4 as uuidV4 } from 'uuid'
 
 const settingsStore = useSettingsStore()
+
+const { colors, setCustomLabel } = useLabelColors()
 
 const props = defineProps<{
   dialogOpened: boolean
@@ -66,7 +69,9 @@ const form = ref<Required<MqttConnection>>({
     qos: 0,
     retain: false,
     payload: ''
-  }
+  },
+
+  labelColor: null
 })
 
 const addTopicForm = ref<MqttTopicSubscription>({
@@ -106,6 +111,8 @@ const clearForm = () => {
     retain: false,
     payload: ''
   }
+
+  form.value.labelColor = null
 
   settingsCategoryTab.value = 'general'
 }
@@ -207,6 +214,17 @@ const mqttProtocolOptions = [
   { label: 'wss://', value: 'wss' }
 ]
 
+const labelOptions = computed<Array<{ label: string; value: string | null; bg?: string }>>(() => {
+  const colorItems = colors.value ?? []
+
+  return [
+    { label: 'None', value: null, bg: 'tw-bg-transparent' },
+    ...colorItems.map(({ bg, label, value }) => ({ label, value, bg }))
+  ]
+})
+
+const selectedColor = computed(() => colors.value.find((o) => o.value === form.value.labelColor))
+
 const rules = {
   name: [(v: string) => !!v || 'Name is required'],
   protocol: [(v: string) => !!v || 'Protocol is required'],
@@ -254,8 +272,61 @@ watch(
           >
             <q-tab-panel name="general" class="tw-overflow-x-hidden">
               <q-form ref="generalSettingsFormRef" class="tw-flex tw-h-96 tw-flex-col tw-gap-4">
-                <div>
-                  <q-input v-model="form.name" filled label="Name" :rules="rules.name" />
+                <div class="tw-flex tw-gap-4">
+                  <q-input
+                    v-model="form.name"
+                    filled
+                    label="Name"
+                    :rules="rules.name"
+                    class="tw-flex-grow"
+                  />
+                  <q-select
+                    v-model="form.labelColor"
+                    :options="labelOptions"
+                    class="tw-min-w-[128px]"
+                    filled
+                    label="Label"
+                    emit-value
+                  >
+                    <template #selected-item>
+                      <div v-if="selectedColor" class="tw-space-x-2">
+                        <q-chip size="xs" :class="selectedColor?.bg" />
+                        {{ selectedColor?.label }}
+                      </div>
+                    </template>
+                    <template #option="{ itemProps, opt }">
+                      <q-item v-bind="itemProps">
+                        <q-item-section class="items-center tw-grid tw-grid-cols-[auto_1fr]">
+                          <q-chip size="xs" :class="opt.bg" />
+                          <q-item-label>{{ opt.label }}</q-item-label>
+                        </q-item-section>
+                      </q-item>
+                    </template>
+                    <template #after>
+                      <q-btn v-if="selectedColor" class="tw-h-full" size="xs" color="accent">
+                        <q-icon name="fa-solid fa-pen" />
+                        <q-tooltip>Edit label name</q-tooltip>
+                        <q-popup-edit
+                          v-slot="scope"
+                          :model-value="selectedColor.label"
+                          auto-save
+                          @update:model-value="setCustomLabel(selectedColor.value, $event)"
+                        >
+                          <div class="text-accent tw-mb-1">My Custom Title</div>
+
+                          <q-input
+                            v-model="scope.value"
+                            color="accent"
+                            clearable
+                            autofocus
+                            dense
+                            filled
+                            @keyup.enter="scope.set"
+                          />
+                        </q-popup-edit>
+                      </q-btn>
+                    </template>
+                  </q-select>
                 </div>
                 <div class="tw-flex tw-gap-4">
                   <q-select

--- a/src/renderer/src/composables/useLabelColors.ts
+++ b/src/renderer/src/composables/useLabelColors.ts
@@ -1,6 +1,8 @@
 import { computed } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 
+const TAILWIND_CLASS_PREFIX = 'tw-'
+
 const COLORS = [
   { label: 'Red', value: 'red' },
   { label: 'Orange', value: 'orange' },
@@ -21,8 +23,6 @@ const COLORS = [
   { label: 'Rose', value: 'rose' }
 ]
 
-const TW_PREFIX = 'tw-'
-
 export function useLabelColors() {
   const customColorLabels = useLocalStorage<{ [key: string]: string }>('label-names', {})
 
@@ -35,8 +35,8 @@ export function useLabelColors() {
     COLORS.map((color) => ({
       ...color,
       label: customColorLabels.value[color.value] || color.label,
-      bg: `${TW_PREFIX}bg-${color.value}-500`,
-      border: `${TW_PREFIX}border-${color.value}-500`
+      bg: `${TAILWIND_CLASS_PREFIX}bg-${color.value}-500`,
+      border: `${TAILWIND_CLASS_PREFIX}border-${color.value}-500`
     }))
   )
 

--- a/src/renderer/src/composables/useLabelColors.ts
+++ b/src/renderer/src/composables/useLabelColors.ts
@@ -1,0 +1,52 @@
+import { computed } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
+
+const COLORS = [
+  { label: 'Red', value: 'red' },
+  { label: 'Orange', value: 'orange' },
+  { label: 'Amber', value: 'amber' },
+  { label: 'Yellow', value: 'yellow' },
+  { label: 'Lime', value: 'lime' },
+  { label: 'Green', value: 'green' },
+  { label: 'Emerald', value: 'emerald' },
+  { label: 'Teal', value: 'teal' },
+  { label: 'Cyan', value: 'cyan' },
+  { label: 'Sky', value: 'sky' },
+  { label: 'Blue', value: 'blue' },
+  { label: 'Indigo', value: 'indigo' },
+  { label: 'Violet', value: 'violet' },
+  { label: 'Purple', value: 'purple' },
+  { label: 'Fuchsia', value: 'fuchsia' },
+  { label: 'Pink', value: 'pink' },
+  { label: 'Rose', value: 'rose' }
+]
+
+const TW_PREFIX = 'tw-'
+
+export function useLabelColors() {
+  const customColorLabels = useLocalStorage<{ [key: string]: string }>('label-names', {})
+
+  const getColor = (value?: string | null) => colors.value.find((o) => o.value === value)
+
+  const getLabel = (value?: string | null) =>
+    customColorLabels.value[value || ''] || getColor(value)?.label || value || ''
+
+  const colors = computed(() =>
+    COLORS.map((color) => ({
+      ...color,
+      label: customColorLabels.value[color.value] || color.label,
+      bg: `${TW_PREFIX}bg-${color.value}-500`,
+      border: `${TW_PREFIX}border-${color.value}-500`
+    }))
+  )
+
+  const setCustomLabel = (value: string, label: string) => {
+    customColorLabels.value[value] = label
+  }
+
+  const removeCustomLabel = (value: string) => {
+    delete customColorLabels.value[value]
+  }
+
+  return { colors, getColor, getLabel, setCustomLabel, removeCustomLabel }
+}

--- a/src/types/mqtt-connection.ts
+++ b/src/types/mqtt-connection.ts
@@ -41,6 +41,8 @@ export type MqttConnection = {
     retain: boolean
     payload: string
   }
+
+  labelColor?: string | null
 }
 
 export type MqttConnectionStatus = 'connected' | 'connecting' | 'reconnecting' | 'disconnected'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,11 +17,7 @@ export default {
       }
     }
   },
-  safelist: [
-    {
-      pattern: /bg-.*/
-    }
-  ],
+  safelist: [{ pattern: /bg-.*/ }, { pattern: /border-.*/ }],
   important: true,
   plugins: []
 } satisfies Config


### PR DESCRIPTION
- Introduced `labelColor` property for MQTT connections.
- Added a new `useLabelColors` composable to manage label colors.
- Enhanced connection tabs and cards with color-coded borders based on labels.
- Updated connection dialog to allow selecting and customizing label colors.
- Extended Tailwind safelist with `border-*` classes for dynamic border styles.